### PR TITLE
Update Index Error toDoList.py

### DIFF
--- a/toDoList.py
+++ b/toDoList.py
@@ -17,7 +17,7 @@ class TaskTracker:
         print(f"Task added: {description}")
 
     def delete_task(self, task_id):
-        if 0 <= task_id <= len(self.tasks):
+        if 0 <= task_id < len(self.tasks):  # Condition correction
             removed_task = self.tasks.pop(task_id)
             print(f"Task deleted: {removed_task.description}")
         else:


### PR DESCRIPTION
The condition if 0 <= task_id <= len(self.tasks) has been corrected to if 0 <= task_id < len(self.tasks) to avoid index errors. The previous condition allowed an index equal to the length of the list, which is incorrect.